### PR TITLE
Add AI conventions (Claude Code): Documentation

### DIFF
--- a/.claude/instructions/readme-english-only.md
+++ b/.claude/instructions/readme-english-only.md
@@ -1,0 +1,21 @@
+---
+title: "Documentation Documentation"
+keywords: ["documentation", "readme", "internationalization", "i18n", "english-only", "project-documentation", "accessibility", "contributor-guidelines", "multilingual", "language-standards"]
+category: "documentation"
+created_from: "PR #2, Comment by sunio00000"
+created_at: "2026-01-16"
+last_updated: "2026-01-16"
+llm_enhanced: true
+---
+# Documentation Documentation
+
+## 요약
+README documentation must be written exclusively in English, not in Korean or other languages.
+
+## 규칙
+All README files in the project should be written in English to ensure accessibility and maintainability for international contributors and users. Using Korean or other non-English languages limits the audience and makes it difficult for developers from different regions to understand the project documentation. This is a high-priority (P1) guideline that should be followed consistently across all project documentation.
+
+## 출처
+이 컨벤션은 [PR #2](https://github.com/sunio00000/review-to-instruction/pull/2)의 리뷰 과정에서 확립되었습니다.
+- 작성자: sunio00000
+- 작성일: 2026. 1. 16.


### PR DESCRIPTION
## 개요
PR #2의 리뷰 과정에서 확립된 컨벤션을 여러 AI 도구용 instruction으로 추가했습니다.

## 변경 사항

### 공통 정보
- 카테고리: documentation
- 키워드: documentation, readme, internationalization, i18n, english-only, project-documentation, accessibility, contributor-guidelines, multilingual, language-standards

### 생성된 파일
1. **Claude Code** (신규)
   - 파일: `.claude/instructions/readme-english-only.md`

## 출처
- 원본 PR: #2
- 코멘트 작성자: @sunio00000
- 코멘트 링크: https://github.com/sunio00000/review-to-instruction/pull/2

## 생성된 파일 미리보기

### 1. Claude Code (`.claude/instructions/readme-english-only.md`)

```markdown
---
title: "Documentation Documentation"
keywords: ["documentation", "readme", "internationalization", "i18n", "english-only", "project-documentation", "accessibility", "contributor-guidelines", "multilingual", "language-standards"]
category: "documentation"
created_from: "PR #2, Comment by sunio00000"
created_at: "2026-01-16"
last_updated: "2026-01-16"
llm_enhanced: true
---
# Documentation Documentation

## 요약
README documentation must be written exclusively in English, not in Korean or other languages.

## 규칙
All README files in the project should be written in English to ensure accessibility and maintainability for international contributors and users. Using Korean or other non-English languages limits the audience and makes it difficult for developers from different regions to understand the project documentation. This is a high-priority (P1) guideline that should be followed consistently across all project documentation.

## 출처
이 컨벤션은 [PR #2](https://github.com/sunio00000/review-to-instruction/pull/2)의 리뷰 과정에서 확립되었습니다.
- 작성자: sunio00000
...
```

---

🤖 이 PR은 [Review to Instruction](https://github.com/sunio00000/review-to-instruction)에 의해 자동 생성되었습니다.